### PR TITLE
Add black and white filter for achievements what are not achieved yet

### DIFF
--- a/src/ts/Mappers.ts
+++ b/src/ts/Mappers.ts
@@ -23,7 +23,7 @@ export function retroAchievementToSteamAchievement(achievement: Achievement, gam
 				.replace("?", "")
 				.replace(".", "")
 			: "",
-		strImage: `https://media.retroachievements.org/Badge/${!!(achievement.badgeName) ? achievement.badgeName : "0"}.png`,
+		strImage: achievement.dateEarned ? `https://media.retroachievements.org/Badge/${!!(achievement.badgeName) ? achievement.badgeName : "0"}.png` : `https://media.retroachievements.org/Badge/${!!(achievement.badgeName) ? achievement.badgeName : "0"}_lock.png`,
 		strName: (achievement.title) ? ((achievement.dateEarnedHardcore ? "[HARDCORE] " : (achievement.dateEarned ? "[ACHIEVED] " : "[NOT ACHIEVED] ")) + (achievement.title.includes("[m]") ? "[MISSABLE] " : "") + achievement.title.replace("[m]", "")) : "",
 	};
 }


### PR DESCRIPTION
Motivation:
**Provides more authentic look as in native Steam Achievements list**

<details>
  <summary>Emuchievements (PR)</summary>
  
![image](https://github.com/user-attachments/assets/095817cc-8010-4496-a708-f1dc43d75843)
</details>


<details>
  <summary>STEAM</summary>
  
![image](https://github.com/user-attachments/assets/305e1bcd-087f-472a-98e5-6071e13afb5e)
</details>
