### PR TITLE
Fixed bug when in some cases "RetroAchievements" settings page does not appear

### DIFF
--- a/src/ts/components/settingsComponent.tsx
+++ b/src/ts/components/settingsComponent.tsx
@@ -132,12 +132,10 @@ export const SettingsComponent: VFC = () =>
 		{
 			title: t("settingsGeneral"),
 			content: <GeneralSettings />,
-			route: '/general',
 		},
 		{
 			title: t("settingsRetroAchievements"),
 			content: <RetroAchievementsSettings />,
-			route: '/retroachievements'
 		}
 	]} />;
 };


### PR DESCRIPTION
After some time of debugging I found that `route` parameter was not really used. 
If we remove it, `RetroAchievementsSettings` component start to show for user.


![image](https://github.com/user-attachments/assets/7d72a9b5-4326-4237-936f-6f912419cc12)
