### PR TITLE
Implement "Show achievements prefixes" option into settings

### DIFF
--- a/src/ts/AchievementsManager.ts
+++ b/src/ts/AchievementsManager.ts
@@ -473,7 +473,7 @@ export class AchievementManager implements Manager
 			.reduce((result, [_, achievement]) =>
 			{
 				this.logger.debug('Achievement: ', achievement);
-				const steam = retroAchievementToSteamAchievement(achievement, retro.game);
+				const steam = retroAchievementToSteamAchievement(achievement, retro.game, this.state.settings.general.show_achieved_state_prefixes);
 
 				if (result.user.data && result.global.data)
 				{
@@ -573,6 +573,7 @@ export class AchievementManager implements Manager
 		const user = this.userAchievements[app_id] ?? this.achievements[0];
 		const global = this.globalAchievements[app_id] ?? this.globalAchievements[0];
 		const retro = this.achievements[app_id];
+
 		if (loading)
 		{
 			return loadingFetchedAchievements;

--- a/src/ts/Mappers.ts
+++ b/src/ts/Mappers.ts
@@ -1,7 +1,48 @@
 import { SteamAppAchievement } from "./SteamTypes";
 import { GameExtendedAchievementEntityWithUserProgress as Achievement, GameInfoAndUserProgress as Game, GetGameInfoAndUserProgressResponse as GameRaw } from "@retroachievements/api";
 
-export function retroAchievementToSteamAchievement(achievement: Achievement, game: Game): SteamAppAchievement
+function getAchievementTitle(achievement: Achievement, showAchievedStatePrefixes: boolean = true) {
+	let achievementTitle = '';
+
+	if (!achievement.title) {
+		return '';
+	}
+
+	if (achievement.dateEarnedHardcore) {
+		achievementTitle += "[HARDCORE]";
+	}
+
+	if (showAchievedStatePrefixes) {
+		if (achievement.dateEarned) {
+			achievementTitle += "[ACHIEVED] ";
+		} else {
+			achievementTitle += "[NOT ACHIEVED] ";
+		}
+	}
+
+	if (achievement.title.includes("[m]")) {
+		achievementTitle += "[MISSABLE] ";
+	}
+
+	achievementTitle += achievement.title
+		.replace("[m]", "")
+		// NOTE: Removes spaces between `[HARDCORE][ACHIEVED] [MISSABLE]`
+		.replace(/\]\s\[/g, '][');
+
+	return achievementTitle;
+}
+
+function getAchievementImage(achievement: Achievement) {
+	const { badgeName } = achievement;
+
+	if (achievement.dateEarned) {
+		return `https://media.retroachievements.org/Badge/${badgeName ? badgeName : "0"}.png`
+	}
+
+	return `https://media.retroachievements.org/Badge/${badgeName ? badgeName : "0"}_lock.png`
+}
+
+export function retroAchievementToSteamAchievement(achievement: Achievement, game: Game, showPrefixes: boolean): SteamAppAchievement
 {
 	return {
 		bAchieved: !!(achievement.dateEarned),
@@ -23,8 +64,8 @@ export function retroAchievementToSteamAchievement(achievement: Achievement, gam
 				.replace("?", "")
 				.replace(".", "")
 			: "",
-		strImage: achievement.dateEarned ? `https://media.retroachievements.org/Badge/${!!(achievement.badgeName) ? achievement.badgeName : "0"}.png` : `https://media.retroachievements.org/Badge/${!!(achievement.badgeName) ? achievement.badgeName : "0"}_lock.png`,
-		strName: (achievement.title) ? ((achievement.dateEarnedHardcore ? "[HARDCORE] " : (achievement.dateEarned ? "[ACHIEVED] " : "[NOT ACHIEVED] ")) + (achievement.title.includes("[m]") ? "[MISSABLE] " : "") + achievement.title.replace("[m]", "")) : "",
+		strImage: getAchievementImage(achievement),
+		strName: getAchievementTitle(achievement, showPrefixes),
 	};
 }
 

--- a/src/ts/components/settingsComponent.tsx
+++ b/src/ts/components/settingsComponent.tsx
@@ -75,12 +75,37 @@ const GeneralSettings: VFC = () =>
 	}}>
 		<PanelSection title={t("settingsGeneral")}>
 			<PanelSectionRow>
-				<ToggleField label={t("settingsGamePage")} checked={settings.general.game_page}
-					onChange={async (checked) => { settings.general.game_page = checked; await settings.writeSettings(); }} />
+				<ToggleField
+					label={t("settingsGamePage")}
+					checked={settings.general.game_page}
+					onChange={async (checked) => {
+						settings.general.game_page = checked;
+						await settings.writeSettings();
+					}}
+				/>
 			</PanelSectionRow>
+
 			<PanelSectionRow>
-				<ToggleField label={t("settingsStoreCategory")} checked={settings.general.store_category}
-					onChange={async (checked) => { settings.general.store_category = checked; await settings.writeSettings(); }} />
+				<ToggleField
+					label={t("settingsStoreCategory")}
+					checked={settings.general.store_category}
+					onChange={async (checked) => {
+						settings.general.store_category = checked;
+						await settings.writeSettings();
+					}}
+				/>
+			</PanelSectionRow>
+
+			<PanelSectionRow>
+				<ToggleField
+					label={t("settingsShowAchievementsPrefixes")}
+					checked={settings.general.show_achieved_state_prefixes ?? true}
+					onChange={async (checked) => {
+						settings.general.show_achieved_state_prefixes = checked;
+						await settings.writeSettings();
+					}}
+					description={t('settingsShowAchievementsPrefixesDescription')}
+				/>
 			</PanelSectionRow>
 		</PanelSection>
 	</div>);
@@ -343,4 +368,4 @@ export const SettingsComponent: VFC = () =>
 			content: <CustomIdsOverrides />,
 		}
 	]} />;
-}
+};

--- a/src/ts/localisation/bg.json
+++ b/src/ts/localisation/bg.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/cs.json
+++ b/src/ts/localisation/cs.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Obecné",
 	"settingsGamePage": "Zobrazit na stránce hry",
 	"settingsStoreCategory": "Přidat ikonu kategorie obchodu",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/da.json
+++ b/src/ts/localisation/da.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Generelt",
 	"settingsGamePage": "Vis på spilside",
 	"settingsStoreCategory": "Tilføj Butiks Kategori Ikon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroOpnåelser",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/de.json
+++ b/src/ts/localisation/de.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Allgemein",
 	"settingsGamePage": "In Spielseite anzeigen",
 	"settingsStoreCategory": "Store-Kategorie-Icon hinzufügen",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/el.json
+++ b/src/ts/localisation/el.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Γενικά",
 	"settingsGamePage": "Εμφάνιση στη σελίδα παιχνιδιού",
 	"settingsStoreCategory": "Προσθήκη Εικονιδίου Κατηγορίας Καταστήματος",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/en.json
+++ b/src/ts/localisation/en.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/es-419.json
+++ b/src/ts/localisation/es-419.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Mostrar en la página del juego",
 	"settingsStoreCategory": "Añadir icono de categoría de tienda",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/es.json
+++ b/src/ts/localisation/es.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Ajustes generales",
 	"settingsGamePage": "Mostrar en la página del juego",
 	"settingsStoreCategory": "Añadir icono de categoría de tienda",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/fi.json
+++ b/src/ts/localisation/fi.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Yleiset",
 	"settingsGamePage": "Näytä pelin sivulla",
 	"settingsStoreCategory": "Lisää Kaupan Kategoriakuvake",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "Takautuvat Saavutukset",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/fr.json
+++ b/src/ts/localisation/fr.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Général",
 	"settingsGamePage": "Afficher dans la page du jeu",
 	"settingsStoreCategory": "Ajouter une icône de catégorie de magasin",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/hu.json
+++ b/src/ts/localisation/hu.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/it.json
+++ b/src/ts/localisation/it.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Generale",
 	"settingsGamePage": "Mostra nella pagina di gioco",
 	"settingsStoreCategory": "Aggiungi Icona Categoria Negozio",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/ja.json
+++ b/src/ts/localisation/ja.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "全般",
 	"settingsGamePage": "ゲームページに表示",
 	"settingsStoreCategory": "ストアカテゴリアイコンを追加",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievents",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/ko.json
+++ b/src/ts/localisation/ko.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "일반",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/nl.json
+++ b/src/ts/localisation/nl.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Algemeen",
 	"settingsGamePage": "Weergeven in Spelpagina",
 	"settingsStoreCategory": "Voeg winkel categorie icoon toe",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/no.json
+++ b/src/ts/localisation/no.json
@@ -2,6 +2,8 @@
 	"settingsTitle": "Emuchievements Innstillinger",
 	"settingsGeneral": "Generelt",
 	"settingsGamePage": "Vis på side rundt spill",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsStoreCategory": "Legg til butikkkategorikon",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",

--- a/src/ts/localisation/pl.json
+++ b/src/ts/localisation/pl.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Ogólne",
 	"settingsGamePage": "Pokaż na stronie gry",
 	"settingsStoreCategory": "Dodaj ikonę kategorii sklepu",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/pt-br.json
+++ b/src/ts/localisation/pt-br.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Geral",
 	"settingsGamePage": "Mostrar na página do jogo",
 	"settingsStoreCategory": "Adicionar ícone de categoria da loja",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/pt.json
+++ b/src/ts/localisation/pt.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Gerais",
 	"settingsGamePage": "Mostrar na página do jogo",
 	"settingsStoreCategory": "Adicionar ícone de categoria da loja",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroConquistas",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/ro.json
+++ b/src/ts/localisation/ro.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Generalități",
 	"settingsGamePage": "Arată în pagina jocului",
 	"settingsStoreCategory": "Adaugă Iconiță Categorie Magazin",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "Realizări",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/ru.json
+++ b/src/ts/localisation/ru.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Общее",
 	"settingsGamePage": "Показать на странице игры",
 	"settingsStoreCategory": "Добавить иконку категории магазина",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/sv.json
+++ b/src/ts/localisation/sv.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Allmänt",
 	"settingsGamePage": "Visa i spelsidan",
 	"settingsStoreCategory": "Lägg till butikskategori ikon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "Uppgifter",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/th.json
+++ b/src/ts/localisation/th.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/tr.json
+++ b/src/ts/localisation/tr.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/uk.json
+++ b/src/ts/localisation/uk.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "Загальні налаштування",
 	"settingsGamePage": "Показати на сторінці гри",
 	"settingsStoreCategory": "Додати піктограму категорії магазину",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "РетроДосягнення",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/vi.json
+++ b/src/ts/localisation/vi.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/zh-cn.json
+++ b/src/ts/localisation/zh-cn.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "A. 概况",
 	"settingsGamePage": "在游戏页面显示",
 	"settingsStoreCategory": "添加商店类别图标",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "2. 成就",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/localisation/zh-tw.json
+++ b/src/ts/localisation/zh-tw.json
@@ -3,6 +3,8 @@
 	"settingsGeneral": "General",
 	"settingsGamePage": "Show in Game Page",
 	"settingsStoreCategory": "Add Store Category Icon",
+	"settingsShowAchievementsPrefixes": "Show achievements prefixes",
+	"settingsShowAchievementsPrefixesDescription": "Show or hide prefixes [ACHIEVED] & [NOT ACHIEVED] from achievement name. For some games may need a full Steam Deck restart to actualize changes.",
 	"settingsRetroAchievements": "RetroAchievements",
 	"settingsCustomIdsOverrides": "Custom IDs Overrides",
 	"settingsCustomIdsOverridesSave": "Save",

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -40,6 +40,10 @@ export type CacheData = {
 export type GeneralData = {
 	game_page: boolean,
 	store_category: boolean,
+	/**
+	 * Enabled or disable showing prefixes like `[ACHIEVED]` & `[NOT ACHIEVED]`
+	 */
+	show_achieved_state_prefixes: boolean,
 };
 
 export const CONFIG_VERSION = "1.1.0";
@@ -57,6 +61,7 @@ const DEFAULT_CONFIG: SettingsData = {
 	general: {
 		game_page: true,
 		store_category: true,
+		show_achieved_state_prefixes: true,
 	},
 };
 


### PR DESCRIPTION
**Motivation**:
1. Provides same experience as native STEAM achievements list.
2. Allow user to control how achievements would look:

**ENABLED Prefixes**:
![image](https://github.com/user-attachments/assets/7bd44f7f-6518-4b64-aa7d-15f0f0705b61)

**DISABLED Prefixes**:
![image](https://github.com/user-attachments/assets/66933588-89b3-4496-bf58-a866650795b4)

Settings:
![image](https://github.com/user-attachments/assets/b49dd35a-4ba5-4045-aec6-aa1b658c0339)
