### PR TITLE
Add: Support for Gamecube ISO Rom Hashing

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -8,8 +8,8 @@ set(${PROJECT_NAME}_SOURCE
 )
 
 set(RCHEEVOS_SOURCE
-        src/rcheevos/src/rcheevos/compat.c
         src/rcheevos/src/rhash/cdreader.c
+        src/rcheevos/src/rhash/aes.c
         src/rcheevos/src/rhash/hash.c
         src/rcheevos/src/rhash/md5.c
 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emuchievements",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"description": "Plugin for viewing RetroAchievements progress. Part of the EmuDeck Project",
 	"scripts": {
 		"build": "shx rm -rf dist && rollup -c",
@@ -10,7 +10,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/EmuDeck/Emuchievements.git"
+		"url": "git+https://github.com/mrosenbergtech/Emuchievements/Emuchievements.git"
 	},
 	"keywords": [
 		"decky",
@@ -20,12 +20,12 @@
 		"retroachievements",
 		"EmuDeck"
 	],
-	"author": "Witherking25 'Kernel Panic' <witherking@withertech.com>",
+	"author": "Witherking25 'Kernel Panic' <witherking@withertech.com> | mrosenbergtech",
 	"license": "GPL-3",
 	"bugs": {
-		"url": "https://github.com/EmuDeck/Emuchievements/issues"
+		"url": "https://github.com/mrosenbergtech/Emuchievements/issues"
 	},
-	"homepage": "https://github.com/EmuDeck/Emuchievements#readme",
+	"homepage": "https://github.com/mrosenbergtech/Emuchievements/#readme",
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^21.1.0",
 		"@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emuchievements",
-	"version": "2.0.5",
+	"version": "2.0.5-beta",
 	"description": "Plugin for viewing RetroAchievements progress. Part of the EmuDeck Project",
 	"scripts": {
 		"build": "shx rm -rf dist && rollup -c",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/mrosenbergtech/Emuchievements/Emuchievements.git"
+		"url": "git+https://github.com/EmuDeck/Emuchievements.git"
 	},
 	"keywords": [
 		"decky",
@@ -20,12 +20,13 @@
 		"retroachievements",
 		"EmuDeck"
 	],
-	"author": "Witherking25 'Kernel Panic' <witherking@withertech.com> | mrosenbergtech",
+	"author": "Witherking25 'Kernel Panic' <witherking@withertech.com>",
+	"contributors": ["mrosenbergtech"],
 	"license": "GPL-3",
 	"bugs": {
-		"url": "https://github.com/mrosenbergtech/Emuchievements/issues"
+		"url": "https://github.com/EmuDeck/Emuchievements/issues"
 	},
-	"homepage": "https://github.com/mrosenbergtech/Emuchievements/#readme",
+	"homepage": "https://github.com/Emudeck/Emuchievements#readme",
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^21.1.0",
 		"@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"bugs": {
 		"url": "https://github.com/EmuDeck/Emuchievements/issues"
 	},
-	"homepage": "https://github.com/Emudeck/Emuchievements#readme",
+	"homepage": "https://github.com/EmuDeck/Emuchievements#readme",
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^21.1.0",
 		"@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emuchievements",
-	"version": "2.0.5-beta",
+	"version": "2.0.5",
 	"description": "Plugin for viewing RetroAchievements progress. Part of the EmuDeck Project",
 	"scripts": {
 		"build": "shx rm -rf dist && rollup -c",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Emuchievements",
-  "author": "Witherking25  'Kernel Panic' | mrosenbergtech",
+  "author": "Witherking25  'Kernel Panic', mrosenbergtech",
   "flags": [],
   "publish": {
     "tags": ["EmuDeck", "retroachievements"],

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Emuchievements",
-  "author": "Witherking25  'Kernel Panic'",
-  "flags": ["debug"],
+  "author": "Witherking25  'Kernel Panic' | mrosenbergtech",
+  "flags": [],
   "publish": {
     "tags": ["EmuDeck", "retroachievements"],
     "description": "Plugin for viewing RetroAchievements progress. Part of the EmuDeck Project",


### PR DESCRIPTION
![tempImagezPtDIz](https://github.com/user-attachments/assets/6d7f6b37-7195-48df-9110-54bcf8c92414)

Add support for Gamecube ISO Rom Hashing. Note this does not work for CISO files.