### PR TITLE
Fix build instructions in README to match package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,13 @@ Decky Loader Steam Deck Plugin for viewing RetroAchievements progress.
 ## Building
 
 ```bash
-
-pnpm i # Installs dependencies
-
-pnpm package # Builds installable zip file
-
-pnpm start # deploys to your deck if you have your vscode config set up for deployment (developer thing)
-
+pnpm i       # Installs dependencies
+pnpm build   # Builds the plugin (production)
+pnpm dev     # Builds the plugin (development mode)
+pnpm watch   # Builds and watches for changes
 ```
 
-vscode and intellj IDEA run configs are included
+vscode and intellij IDEA run configs are included
 
 ## Translation
 


### PR DESCRIPTION
## Summary

Fixes #61.

The README references `pnpm package` and `pnpm start`, but neither script exists in `package.json`. These were likely from an older build setup before the migration to rollup.

Updated the Building section to list the actual available scripts:

| README (before) | README (after) | Exists in package.json? |
|---|---|---|
| `pnpm package` | `pnpm build` | Yes |
| `pnpm start` | `pnpm dev` | Yes |
| *(not listed)* | `pnpm watch` | Yes |

Also fixed a small typo: "intellj" -> "intellij".